### PR TITLE
Making the MCP key var sensitive

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,7 @@ variable "key" {
   description = "Key."
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "loop_detection" {


### PR DESCRIPTION
This tag hides a variable from terraform command outputs and logs.